### PR TITLE
point build status link at travis-ci.com instead of travis-ci.org; bump python versions tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "pypy3.5"
+  - "3.7"
+  - "3.8"
+  - "pypy3.5-6.0"
 before_script:
   - wget https://github.com/kr/beanstalkd/archive/v1.10.tar.gz -O /tmp/beanstalkd.tar.gz
   - tar -C /tmp -xvf /tmp/beanstalkd.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 *beancmd* is a simple ops-focused command-line for [beanstalkd](http://kr.github.io/beanstalkd/) written in Python.
 
-[![Build Status](https://travis-ci.org/EasyPost/beancmd.svg?branch=master)](https://travis-ci.org/EasyPost/beancmd)
+[![Build Status](https://travis-ci.com/EasyPost/beancmd.svg?branch=master)](https://travis-ci.com/EasyPost/beancmd)
 
 ## Dependencies
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Intended Audience :: System Administrators",
         "Operating System :: OS Independent",
         "Topic :: Database",


### PR DESCRIPTION
this repo needs more love, but here's a start