### PR TITLE
verify specified tubes exist before executing for certain commands

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+## These are the standard rules for all EasyPost repositories, this should be
+## updated as needed.
+##
+
+# By default all the files in this repo are owned by the team that owns the repo.
+* @easypost/infra-eng
+
+# The devtools team owns the codeowners file, this is for auditing purposes
+.github/CODEOWNERS @easypost/dev-tools
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           make
           mv beanstalkd ~/beanstalks/
       - name: set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.pythonversion }}
       - name: install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   run-tests:
     env:
       BEANSTALK_VERSION: '1.12'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6']
+        pythonversion: ['3.9', 'pypy-3.6']
     steps:
       - uses: actions/checkout@v2
       - name: cache beanstalkd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: cache beanstalkd
         id: cache-beanstalkd
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/beanstalks
           key: ${{ runner.os }}-${{ env.BEANSTALK_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ jobs:
     env:
       BEANSTALK_VERSION: '1.12'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        pythonversion: ['3.9', 'pypy-3.6']
     steps:
       - uses: actions/checkout@v2
       - name: cache beanstalkd
@@ -33,12 +30,8 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.pythonversion }}
-      - name: install dependencies
-        run: "python -m pip install -r requirements-tests.txt -e ."
-      - name: lint with flake8
-        run: flake8 beancmd/ tests/
-      - name: test with pytest
-        run: pytest --cov=beancmd/ --cov-report=term-missing --cov-fail-under=60 tests/
+          python-version: 3.9
+      - name: make test
+        run: "make test"
         env:
           BEANSTALKD_PATH: ~/beanstalks/beanstalkd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   run-tests:
     env:
       BEANSTALK_VERSION: '1.12'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         pythonversion: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           make
           mv beanstalkd ~/beanstalks/
       - name: set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.pythonversion }}
       - name: install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+venv
 venv/
 env/
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-0.4.3
+0.5.0
 _____
 - The `bury`, `flush`, `kick`, `pause`, and `purge_buried` commands now verify that,
 if given a specific set of tube names, those tubes exist on the given server before

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+0.4.3
+_____
+- The `bury`, `flush`, `kick`, `pause`, and `purge_buried` commands now verify that,
+if given a specific set of tube names, those tubes exist on the given server before
+proceeding. This is in order to reduce confusion for sensitive or destructive 
+commands.
+
 0.4.2
 -----
 - Do not include tests in distributed package even when not processing `MANIFEST.in`

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+VIRTUALENV := $(if $(GITHUB_ACTIONS),python -m venv,/opt/python3.9/bin/virtualenv)
+EP_ENVIRONMENT ?= local
+WITHENV = $(if $(GITHUB_ACTIONS),,withenv)
+
+help:
+	@cat Makefile | grep '^## ' | cut -c4- | sed -e 's/ - /\t- /;' | column -s "$$( echo -e '\t' )" -t
+
+## install - Fully install the service locally
+install: venv/requirements_installed
+
+## clean - Remove the virtual environment, drop all databases and clear out .pyc files
+clean:
+	rm -rf ~/.venv/beancmd/ venv
+	find . -name '*.pyc' -delete
+
+## venv - Install the virtual environment
+venv/bin/pip:
+ifeq ($(EP_ENVIRONMENT), local)
+	$(VIRTUALENV) ~/.venv/beancmd/
+	ln -snfT ~/.venv/beancmd/ venv
+else
+	$(VIRTUALENV) venv
+endif
+
+venv/requirements_installed: venv/bin/pip requirements.txt setup.py
+	$< install -e . -r requirements.txt
+	touch "$@"
+
+venv/test_requirements_installed: venv/bin/pip requirements-tests.txt
+	$< install -r requirements-tests.txt
+	touch "$@"
+
+## run - Run the HTTP service locally
+run: venv/requirements_installed
+	${WITHENV} venv/bin/python -m beancmd.beancmd "$@"
+
+## test - Run unit tests
+test: venv/requirements_installed venv/test_requirements_installed
+ifeq ($(EP_ENVIRONMENT), test)
+	withenv ./venv/bin/py.test --cov beancmd --cov-report=term-missing --timeout=30 --junit-xml="${EPCI_JUNIT_TEST_RESULTS}/pytest.xml" tests/
+else
+	withenv ./venv/bin/py.test --timeout=30 --cov-report=term-missing --cov=beancmd tests/
+endif
+	venv/bin/flake8 beancmd/ tests/
+
+.PHONY: clean help install run test
+
+# vim:noexpandtab:ts=8

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ run: venv/requirements_installed
 ## test - Run unit tests
 test: venv/requirements_installed venv/test_requirements_installed
 ifeq ($(EP_ENVIRONMENT), test)
-	withenv ./venv/bin/py.test --cov beancmd --cov-report=term-missing --timeout=30 --junit-xml="${EPCI_JUNIT_TEST_RESULTS}/pytest.xml" tests/
+	${WITHENV} ./venv/bin/py.test --cov beancmd --cov-report=term-missing --timeout=30 --junit-xml="${EPCI_JUNIT_TEST_RESULTS}/pytest.xml" tests/
 else
-	withenv ./venv/bin/py.test --timeout=30 --cov-report=term-missing --cov=beancmd tests/
+	${WITHENV} ./venv/bin/py.test --timeout=30 --cov-report=term-missing --cov=beancmd tests/
 endif
-	venv/bin/flake8 beancmd/ tests/
+	${WITHENV} venv/bin/flake8 beancmd/ tests/
 
 .PHONY: clean help install run test
 

--- a/beancmd/__init__.py
+++ b/beancmd/__init__.py
@@ -1,3 +1,3 @@
-version_info = (0, 4, 3)
+version_info = (0, 5, 0)
 __version__ = '.'.join(str(s) for s in version_info)
-__author__ = 'James Brown <jbrown@easypost.com>'
+__author__ = 'EasyPost <support@easypost.com>'

--- a/beancmd/__init__.py
+++ b/beancmd/__init__.py
@@ -1,3 +1,3 @@
-version_info = (0, 4, 2)
+version_info = (0, 4, 3)
 __version__ = '.'.join(str(s) for s in version_info)
 __author__ = 'James Brown <jbrown@easypost.com>'

--- a/beancmd/beancmd.py
+++ b/beancmd/beancmd.py
@@ -49,7 +49,11 @@ def main():
         parser.print_help()
         return 2
 
-    return args.func(args)
+    try:
+        return args.func(args)
+    except ValueError as ve:
+        print('Could not run command: {0}'.format(ve))
+        return 2
 
 
 if __name__ == '__main__':

--- a/beancmd/bury.py
+++ b/beancmd/bury.py
@@ -19,7 +19,7 @@ def setup_parser(parser=None):
 def run(args):
     client = pystalk.BeanstalkClient(args.host, args.port)
 
-    tubes = util.get_tubes(client, args.tubes)
+    tubes = util.verify_tubes(client, args.tubes)
 
     client.watch('unused-fake-tube')
     for tube in tubes:

--- a/beancmd/flush.py
+++ b/beancmd/flush.py
@@ -20,7 +20,7 @@ def setup_parser(parser=None):
 def run(args):
     client = pystalk.BeanstalkClient(args.host, args.port)
 
-    tubes = util.get_tubes(client, args.tubes)
+    tubes = util.verify_tubes(client, args.tubes)
 
     if not args.yes:
         util.prompt_yesno('Are you sure you want to flush tubes {0} (y/N)? '.format(', '.join(sorted(tubes))))

--- a/beancmd/kick.py
+++ b/beancmd/kick.py
@@ -31,7 +31,7 @@ def setup_parser(parser=None):
 def run(args):
     client = pystalk.BeanstalkClient(args.host, args.port)
 
-    tubes = util.get_tubes(client, args.tubes)
+    tubes = util.verify_tubes(client, args.tubes)
 
     for tube in tubes:
         # KICK uses USE instead of WATCH

--- a/beancmd/pause.py
+++ b/beancmd/pause.py
@@ -21,7 +21,7 @@ def setup_parser(parser=None):
 def run(args):
     client = pystalk.BeanstalkClient(args.host, args.port)
 
-    tubes = util.get_tubes(client, args.tubes)
+    tubes = util.verify_tubes(client, args.tubes)
 
     for tube in tubes:
         stats = client.stats_tube(tube)

--- a/beancmd/purge_buried.py
+++ b/beancmd/purge_buried.py
@@ -18,15 +18,15 @@ def setup_parser(parser=None):
 def run(args):
     client = pystalk.BeanstalkClient(args.host, args.port)
 
-    given_tubes = set(args.tubes)
-    tubes = util.get_tubes(client, args.tubes)
+    # given_tubes = set(args.tubes)
+    tubes = util.verify_tubes(client, args.tubes)
 
-    if not given_tubes.issubset(tubes):
-        raise ValueError('Cannot find the given tubes ({0}) in the current tubes for the host: {1}'
-                         .format(
-                             given_tubes,
-                             tubes
-                         ))
+    # if not given_tubes.issubset(tubes):
+    #     raise ValueError('Cannot find the given tubes ({0}) in the current tubes for the host: {1}'
+    #                      .format(
+    #                          given_tubes,
+    #                          tubes
+    #                      ))
 
     if not args.yes:
         util.prompt_yesno('Are you sure you want to purge all buried jobs from tubes {0} (y/N)? '.format(

--- a/beancmd/purge_buried.py
+++ b/beancmd/purge_buried.py
@@ -18,7 +18,15 @@ def setup_parser(parser=None):
 def run(args):
     client = pystalk.BeanstalkClient(args.host, args.port)
 
+    given_tubes = set(args.tubes)
     tubes = util.get_tubes(client, args.tubes)
+
+    if not given_tubes.issubset(tubes):
+        raise ValueError('Cannot find the given tubes ({0}) in the current tubes for the host: {1}'
+                         .format(
+                             given_tubes,
+                             tubes
+                         ))
 
     if not args.yes:
         util.prompt_yesno('Are you sure you want to purge all buried jobs from tubes {0} (y/N)? '.format(

--- a/beancmd/purge_buried.py
+++ b/beancmd/purge_buried.py
@@ -18,15 +18,7 @@ def setup_parser(parser=None):
 def run(args):
     client = pystalk.BeanstalkClient(args.host, args.port)
 
-    # given_tubes = set(args.tubes)
     tubes = util.verify_tubes(client, args.tubes)
-
-    # if not given_tubes.issubset(tubes):
-    #     raise ValueError('Cannot find the given tubes ({0}) in the current tubes for the host: {1}'
-    #                      .format(
-    #                          given_tubes,
-    #                          tubes
-    #                      ))
 
     if not args.yes:
         util.prompt_yesno('Are you sure you want to purge all buried jobs from tubes {0} (y/N)? '.format(

--- a/beancmd/stats_tubes.py
+++ b/beancmd/stats_tubes.py
@@ -10,7 +10,7 @@ def setup_parser(parser=None):
         parser = argparse.ArgumentParser()
     parser.add_argument('-H', '--host', default='localhost', help='Host of beanstalk server (default %(default)s)')
     parser.add_argument('-p', '--port', default=11300, type=int, help='Port of beanstalk server (default %(default)s)')
-    parser.add_argument('tubes', nargs='*', help='Tubes to bury from (if not passed, defaults to all)')
+    parser.add_argument('tubes', nargs='*', help='Tubes to get stats about (if not passed, defaults to all)')
     return parser
 
 

--- a/beancmd/util.py
+++ b/beancmd/util.py
@@ -3,6 +3,28 @@ import fnmatch
 
 import tqdm
 
+def verify_tubes(client, initial_tube_list):
+    if not initial_tube_list:
+        return set(client.list_tubes())
+    else:
+        server_tubes = client.list_tubes()
+        tubes = set()
+        missing_tubes = []
+        for tube in initial_tube_list:
+            if '*' in tube or '?' in tube:
+                tubes |= set(f for f in server_tubes if fnmatch.fnmatch(f, tube))
+            elif tube in server_tubes:
+                tubes.add(tube)
+            else:
+                missing_tubes.append(tube)
+        if missing_tubes:
+            raise ValueError('Unable to find requested tubes ({0}) in server tubes ({1})'
+                             .format(
+                                 missing_tubes,
+                                 server_tubes
+                             )
+                             )
+        return tubes
 
 def get_tubes(client, initial_tube_list):
     if not initial_tube_list:

--- a/beancmd/util.py
+++ b/beancmd/util.py
@@ -3,6 +3,7 @@ import fnmatch
 
 import tqdm
 
+
 def verify_tubes(client, initial_tube_list):
     if not initial_tube_list:
         return set(client.list_tubes())
@@ -25,6 +26,7 @@ def verify_tubes(client, initial_tube_list):
                              )
                              )
         return tubes
+
 
 def get_tubes(client, initial_tube_list):
     if not initial_tube_list:

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,6 @@
 pytest==6.2.1
 pytest-cov==2.10.1
+pytest-timeout==2.1.*
 flake8
 mock
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 PyYAML>=3.0
 tqdm>=4.0
-pystalk>=0.4.0,<1.0
+pystalk>=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+from beancmd import __version__
 
 
 install_requires = []
@@ -9,9 +10,9 @@ with open('requirements.txt', 'r') as f:
 
 setup(
     name="beancmd",
-    version="0.4.2",
-    author="James Brown",
-    author_email="jbrown@easypost.com",
+    version=__version__,
+    author="EasyPost",
+    author_email="support@easypost.com",
     url="https://github.com/easypost/beancmd",
     description="Self-contained command-line tool for administrating beanstalkd",
     license="ISC",
@@ -23,14 +24,12 @@ setup(
             'beancmd = beancmd.beancmd:main',
         ]
     },
-    python_requires='>=3.6, <4',
+    python_requires='>=3.9, <4',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Intended Audience :: System Administrators",
         "Operating System :: OS Independent",
         "Topic :: Database",

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -45,11 +45,11 @@ class TestingBeanStalk(object):
 
     def try_startup(self):
         # get a port to bind to
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        s.bind(('localhost', 0))
-        host, port = s.getsockname()
-        s.close()
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(('localhost', 0))
+            host, port = s.getsockname()
+            s.close()
         self.host = host
         self.port = port
         program = os.path.expanduser(os.environ.get('BEANSTALKD_PATH', 'beanstalkd'))
@@ -77,21 +77,23 @@ class TestingBeanStalk(object):
         self.p.wait()
 
     def status(self):
-        s = socket.create_connection((self.host, self.port), timeout=0.25)
-        s.sendall(b'stats\r\n')
-        top, rest = s.recv(1024).split(b'\r\n', 1)
-        status, count = top.split(b' ')
-        count = int(count) + 2
-        bio = io.BytesIO()
-        bytes_read = len(rest)
-        bio.write(rest)
-        while bytes_read < count:
-            message = s.recv(count - bytes_read)
-            if not message:
-                break
-            bio.write(message)
-        bio.seek(0, 0)
-        return yaml.safe_load(bio)
+        with socket.create_connection((self.host, self.port), timeout=0.25) as s:
+            s.sendall(b'stats\r\n')
+            raw = s.recv(1024)
+            top, rest = raw.split(b'\r\n', 1)
+            status, count = top.split(b' ')
+            count = int(count) + 2
+            bio = io.BytesIO()
+            bytes_read = len(rest)
+            bio.write(rest)
+            while bytes_read < count:
+                message = s.recv(count - bytes_read)
+                if not message:
+                    break
+                bio.write(message)
+                bytes_read += len(message)
+            bio.seek(0, 0)
+            return yaml.safe_load(bio)
 
 
 class IntegrationBaseTestCase(TestCase):

--- a/tests/integration/test_list.py
+++ b/tests/integration/test_list.py
@@ -1,6 +1,7 @@
 from .base import IntegrationBaseTestCase
 
 import mock
+from mock import call
 
 from beancmd import list_tubes
 
@@ -16,4 +17,8 @@ class ListTubesTestCase(IntegrationBaseTestCase):
         ])
         with mock.patch('sys.stdout.write') as mock_sys_stdout_write:
             list_tubes.run(args)
-        assert mock_sys_stdout_write.called_once_with('bar\nbaz\ndefault\nfoo\n')
+
+            mock_sys_stdout_write.assert_has_calls([
+                call('bar\nbaz\ndefault\nfoo'),
+                call('\n')
+            ])


### PR DESCRIPTION
Problem

When running `purge_buried` against a tube, the output indicated 0 jobs purged, even though beanmon showed 1 buried job. After a lot of digging around realized that I had incorrectly prepended the tube name with the cluster name, but the tooling never told me that was wrong. (The separate `stats_tubes` command did raise a "tube not found" error, but the prior of `purge_buried` showing 0 and not raising that exception biased me towards thinking something was wrong with the beanmon infrastructure, or the beancmd utility).

Solution

For certain commands, we first verify that the given tubes actually exist before running the logic against them.

I picked the commands where it would be surprising to "see a 0":

* `bury`
* `flush`
* `kick`
* `pause`
* `purge_buried`

Example error message:
```
$ venv/bin/python -m beancmd.beancmd purge_buried -H localhost fdf
Could not run command: Unable to find requested tubes (['fdf']) in server tubes (['default'])
```

Because `beancmd` has not been updated in a while this PR also:

* fixes up a help description.
* changes the `pystalk` client version to match the same dep in `beanmon`.
* introduces a `Makefile` similar to `beanmon` and other python projects.
* because `beancmd` is packaged to use `python-3.9`, `ci.yml` now only uses `3.9`.
* `ci.yml` now delegates creating the venv, installing deps, and running tests to the `make test` target.